### PR TITLE
Fix Julia Data Ingest - Add Packages + DataFrames

### DIFF
--- a/frontend/src/GetDatasetJulia.js
+++ b/frontend/src/GetDatasetJulia.js
@@ -44,8 +44,12 @@ export default function GetDatasetJulia({dataset}) {
 # Dataset and column metadata are under dataset_metadata[x] and 
 # column_metadata[x] respectively.
 
+using Pkg
+
+Pkg.add(["HTTP", "JSON", "DataFrames"])
 using HTTP
 using JSON
+using DataFrames
 
 host = "${host}"
 headers = Dict{String, String}("Authorization" => "Bearer ${token}")


### PR DESCRIPTION
This fixes the Julia API example by adding DataFrames as a package dependency and as well as adding the required packages to the environment.